### PR TITLE
Fix missing escape of ampersand

### DIFF
--- a/GrandsonOfObsidian.tmTheme
+++ b/GrandsonOfObsidian.tmTheme
@@ -5,7 +5,7 @@
 	<key>comment</key>
 	<string>
 		Inspired on Son of Obsidian: http://studiostyl.es/schemes/son-of-obsidian 
-		which is inspired in Obsidian http://www.eclipsecolorthemes.org/?view=theme&id=21
+		which is inspired in Obsidian http://www.eclipsecolorthemes.org/?view=theme&amp;id=21
 		
 		I created this from another theme "Tomorrow Night" http://chriskempson.com
 	</string>


### PR DESCRIPTION
This prevented the theme to be parsed with the system property list parser on OS X.
