### PR TITLE
Added support for GitGutter, using the theme's color palette

### DIFF
--- a/GrandsonOfObsidian.tmTheme
+++ b/GrandsonOfObsidian.tmTheme
@@ -54,7 +54,7 @@
 				<string>#F1F2F3</string>
 			</dict>
 		</dict>
- 		<dict>
+		<dict>
 			<key>name</key>
 			<string>Variable, String Link, Tag Name, FileName</string>
 			<key>scope</key>
@@ -186,6 +186,63 @@
 				<string>#ffffff</string>
 			</dict>
 		</dict>
+
+		<dict>
+			<key>name</key>
+			<string>GitGutter deleted</string>
+			<key>scope</key>
+			<string>markup.deleted.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#EC7600</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter inserted</string>
+			<key>scope</key>
+			<string>markup.inserted.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#93C763</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter changed</string>
+			<key>scope</key>
+			<string>markup.changed.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#81A2BE</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter ignored</string>
+			<key>scope</key>
+			<string>markup.ignored.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#66747B</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter untracked</string>
+			<key>scope</key>
+			<string>markup.untracked.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#66747B</string>
+			</dict>
+		</dict>
+		
 	</array>
 	<key>uuid</key>
 	<string>F96223EB-1AAB-4617-92F3-FA4D4F13DB09</string>


### PR DESCRIPTION
Hi!
I've added support for GitGutter https://github.com/jisaacks/GitGutter, using the example code, but changing the color palette to suit the rest of the theme.